### PR TITLE
在 /api/config 中添加用于配置检索的 GET 端点

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -157,6 +157,10 @@ def delete_folder():
     else :
         return jsonify ({"outcome": "True"}),200
 
+@app.route("/api/config", methods=['GET'])
+def get_config():
+    return jsonify(config)
+
 if __name__ == "__main__":
     # 启动后台线程喵～
     def periodic_task():


### PR DESCRIPTION
此提交添加了一个新的 API 端点，允许客户端通过对 /api/config 的 GET 请求检索当前配置设置。端点以 JSON 格式返回配置数据。